### PR TITLE
DHCP and DNS Cleanup

### DIFF
--- a/roles/dhcp/tasks/main.yml
+++ b/roles/dhcp/tasks/main.yml
@@ -10,9 +10,6 @@
     owner: root
     group: root
     mode: '0644'
-  template:
-    src: dhcpd.conf.j2
-    dest: /etc/dhcp/dhcpd.conf
 
 - name: Enable and start ISC DHCP service
   ansible.builtin.service:

--- a/roles/dns/handlers/main.yml
+++ b/roles/dns/handlers/main.yml
@@ -1,0 +1,5 @@
+- name: Restart BIND
+  ansible.builtin.service:
+    name: named
+    state: restarted
+    enabled: true

--- a/roles/dns/tasks/main.yml
+++ b/roles/dns/tasks/main.yml
@@ -1,12 +1,24 @@
+- name: Install BIND DNS Server
+  ansible.builtin.yum:
+    name: bind
+    state: present
+
 - name: Configure BIND DNS Server
   ansible.builtin.template:
-    src: "{{ item }}.j2"
-    dest: "/etc/named/{{ item }}"
+    src: "named.conf.j2"
+    dest: "/etc/named/named.conf"
+    owner: root
+    group: named
+    mode: '0644'
+
+- name: Configure BIND DNS Zones
+  ansible.builtin.copy:
+    content: "{{ item }}"
+    dest: "/var/named/{{ item }}"
     owner: root
     group: named
     mode: '0644'
   loop:
-    - named.conf
     - db.lab.com
     - db.10.10.10
   notify: restart bind
@@ -15,10 +27,4 @@
   ansible.builtin.service:
     name: named
     state: started
-    enabled: true
-
-- name: Restart BIND
-  ansible.builtin.service:
-    name: named
-    state: restarted
     enabled: true


### PR DESCRIPTION
The DHCP role had duplicate src/dest entries which have been cleaned up. 
DNS was modified to override the /etc/named.conf with the one provided by our Ansible role.
Created a handler to restart named  (DNS) when a new change is pushed.